### PR TITLE
Remove prefix meanings from Mission Mode answer choices

### DIFF
--- a/mission-mode.html
+++ b/mission-mode.html
@@ -564,11 +564,7 @@
       const main = document.createElement("span");
       main.textContent = getPrefixLabel(option);
 
-      const small = document.createElement("small");
-      small.textContent = option.meaning;
-
       inner.appendChild(main);
-      inner.appendChild(small);
       btn.appendChild(inner);
 
       btn.addEventListener("click", () => checkAnswer(option));


### PR DESCRIPTION
Students were being shown the meaning of each prefix alongside the prefix label in the answer bubbles, effectively giving away the answer.